### PR TITLE
Fix: Increase plus/minus button icon sizes (#42)

### DIFF
--- a/lib/ui/screens/character_screen.dart
+++ b/lib/ui/screens/character_screen.dart
@@ -143,7 +143,7 @@ class _CheckmarksAndRetirementsRow extends StatelessWidget {
                 children: [
                   IconButton(
                     padding: EdgeInsets.zero,
-                    iconSize: iconSizeSmall,
+                    iconSize: iconSizeMedium,
                     icon: const Icon(Icons.remove_circle),
                     onPressed: character.previousRetirements > 0 && !isRetired
                         ? () => charactersModel.updateCharacter(
@@ -159,7 +159,7 @@ class _CheckmarksAndRetirementsRow extends StatelessWidget {
                   ),
                   IconButton(
                     padding: EdgeInsets.zero,
-                    iconSize: iconSizeSmall,
+                    iconSize: iconSizeMedium,
                     icon: const Icon(Icons.add_circle),
                     onPressed: !isRetired
                         ? () => charactersModel.updateCharacter(
@@ -200,7 +200,7 @@ class _CheckmarksAndRetirementsRow extends StatelessWidget {
                 children: [
                   IconButton(
                     padding: EdgeInsets.zero,
-                    iconSize: iconSizeSmall,
+                    iconSize: iconSizeMedium,
                     icon: const Icon(Icons.remove_circle),
                     onPressed: character.checkMarks > 0 && !isRetired
                         ? () => charactersModel.decreaseCheckmark(character)
@@ -212,7 +212,7 @@ class _CheckmarksAndRetirementsRow extends StatelessWidget {
                   ),
                   IconButton(
                     padding: EdgeInsets.zero,
-                    iconSize: iconSizeSmall,
+                    iconSize: iconSizeMedium,
                     icon: const Icon(Icons.add_circle),
                     onPressed: character.checkMarks < 18 && !isRetired
                         ? () => charactersModel.increaseCheckmark(character)

--- a/lib/ui/widgets/resource_card.dart
+++ b/lib/ui/widgets/resource_card.dart
@@ -81,6 +81,7 @@ class ResourceDetails extends StatelessWidget {
             bottom: -smallPadding,
             left: -2,
             child: IconButton(
+              iconSize: iconSizeMedium,
               onPressed: () => decreaseCount(),
               icon: const Icon(Icons.remove_circle),
             ),
@@ -89,6 +90,7 @@ class ResourceDetails extends StatelessWidget {
             bottom: -smallPadding,
             right: -2,
             child: IconButton(
+              iconSize: iconSizeMedium,
               onPressed: () => increaseCount(),
               icon: const Icon(Icons.add_circle),
             ),


### PR DESCRIPTION
## Summary
- Increased previous retirements and battle goals plus/minus buttons from `iconSizeSmall` (20px) to `iconSizeMedium` (28px)
- Added explicit `iconSizeMedium` to resource card buttons for consistency (previously relied on Flutter default)

## Test plan
- [ ] Open a character sheet and verify the +/- buttons for previous retirements are larger
- [ ] Verify the +/- buttons for battle goals checkmarks match the retirement buttons
- [ ] Toggle edit mode and verify resource card +/- buttons match the size of the other buttons

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)